### PR TITLE
Add compute_sfs to compute Signal Fluctuation Sensitivity

### DIFF
--- a/compute_sfs.m
+++ b/compute_sfs.m
@@ -1,5 +1,8 @@
 function [sfs] = compute_sfs(meanimg, stdimg, csf, gm, brain)
 % Daniel Gomez 06.11.16
+% COMPUTE_SFS computes the Signal Fluctuation Sensitivity as described in:
+% DeDora 2016 - SFS: An Improved Metric for Optimizing Detection of RSNs.
+% doi:10.3389/fnins.2016.00180
 
 % meanimg, stdimg, csf, gm and brain are loaded niftis.
 % I assume that meanimg and stdimg were already registered to the

--- a/compute_sfs.m
+++ b/compute_sfs.m
@@ -1,0 +1,16 @@
+function [sfs, sfs_img] = compute_sfs(meanimg, stdimg, csf, gm)
+% meanimg, stdimg, csfmask and gmmask are loaded niftis.
+% I assume that meanimg and stdimg were already registered to the
+% anatomical. So please, do that yourself.
+% flirt -in meanimg -ref anat_bet -omat image_mat -out mean_reg
+% flirt -in stdimg -ref anat_bet -applyxfm -init image_mat -out std_reg
+
+
+mu_global = mean(single(meanimg.img(:)));
+mu_gm = meanimg.img .* single(gm.img);
+std_gm = stdimg.img .* single(gm.img);
+std_csf = mean(isfinite(single(stdimg.img(:)) .*single(csf.img(:))));
+
+sfs_img = (mu_gm ./mu_global) .* (std_gm ./std_csf);
+sfs = mean(sfs_img(logical(gm.img)));
+

--- a/compute_sfs.m
+++ b/compute_sfs.m
@@ -1,16 +1,25 @@
-function [sfs, sfs_img] = compute_sfs(meanimg, stdimg, csf, gm)
-% meanimg, stdimg, csfmask and gmmask are loaded niftis.
+function [sfs] = compute_sfs(meanimg, stdimg, csf, gm, brain)
+% Daniel Gomez 06.11.16
+
+% meanimg, stdimg, csf, gm and brain are loaded niftis.
 % I assume that meanimg and stdimg were already registered to the
-% anatomical. So please, do that yourself.
+% anatomical. So please, do that yourself:
 % flirt -in meanimg -ref anat_bet -omat image_mat -out mean_reg
 % flirt -in stdimg -ref anat_bet -applyxfm -init image_mat -out std_reg
+% Apologies if the order of arguments is confusing. Blame MATLAB for not
+% accepting key=value arguments, not me.
 
 
-mu_global = mean(single(meanimg.img(:)));
-mu_gm = meanimg.img .* single(gm.img);
-std_gm = stdimg.img .* single(gm.img);
-std_csf = mean(isfinite(single(stdimg.img(:)) .*single(csf.img(:))));
+mu_global = mean_within_mask(meanimg, brain);
+mu_gm = mean_within_mask(meanimg, gm);
+std_gm = mean_within_mask(stdimg, gm);
+std_csf = mean_within_mask(stdimg, csf);
 
-sfs_img = (mu_gm ./mu_global) .* (std_gm ./std_csf);
-sfs = mean(sfs_img(logical(gm.img)));
+sfs = (mu_gm ./mu_global) .* (std_gm ./std_csf);
 
+
+function value = mean_within_mask(what, mask)
+    value = mean(what.img(logical(mask.img)));
+end
+
+end


### PR DESCRIPTION
Both tSNR and CNR penalize signal fluctuation, which happens to be the most interesting thing to look at when doing rsfMRI.
There is a nice paper that came out this year discussing a new metric called "SFS", which better predicts if a protocol is good or not.

This pull request offers a bare simple implementation of an sfs calculator. 

To be discussed...